### PR TITLE
Fix select item value prop for talep detay

### DIFF
--- a/src/app/[workspaceSlug]/[companySlug]/talep/[talepId]/detay/page.tsx
+++ b/src/app/[workspaceSlug]/[companySlug]/talep/[talepId]/detay/page.tsx
@@ -142,7 +142,7 @@ export default function TalepDetayPage() {
   const [editData, setEditData] = useState({
     status: '',
     priority: '',
-    assignedTo: '',
+    assignedTo: 'unassigned',
     resolution: '',
     actualHours: '',
     actualCost: '',
@@ -181,7 +181,7 @@ export default function TalepDetayPage() {
       setEditData({
         status: data.talep.status,
         priority: data.talep.priority,
-        assignedTo: data.talep.assignedTo || '',
+        assignedTo: data.talep.assignedTo || 'unassigned',
         resolution: data.talep.resolution || '',
         actualHours: data.talep.actualHours?.toString() || '',
         actualCost: data.talep.actualCost?.toString() || '',
@@ -296,7 +296,7 @@ export default function TalepDetayPage() {
       const updatePayload = {
         status: editData.status,
         priority: editData.priority,
-        assignedTo: editData.assignedTo || null,
+        assignedTo: editData.assignedTo === 'unassigned' ? null : editData.assignedTo || null,
         resolution: editData.resolution || null,
         actualHours: editData.actualHours ? parseFloat(editData.actualHours) : null,
         actualCost: editData.actualCost ? parseFloat(editData.actualCost) : null,
@@ -859,7 +859,7 @@ export default function TalepDetayPage() {
                         <SelectValue placeholder="Kullanıcı seçin" />
                       </SelectTrigger>
                       <SelectContent>
-                        <SelectItem value="">Atanmamış</SelectItem>
+                        <SelectItem value="unassigned">Atanmamış</SelectItem>
                         {users.map((user) => (
                           <SelectItem key={user.id} value={user.id}>
                             {user.name || user.email}


### PR DESCRIPTION
Replace empty string `Select.Item` values with "unassigned" to resolve a UI library error.

The `Select.Item` component explicitly disallows empty string values, which was used for the "Unassigned" option. This PR changes the value to "unassigned" and updates the state initialization and API payload handling to correctly manage this new value, converting it back to `null` for the backend.

---
<a href="https://cursor.com/background-agent?bcId=bc-5e23f28a-8c99-4c08-8aa8-57fec515af2a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5e23f28a-8c99-4c08-8aa8-57fec515af2a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

