### PR TITLE
Replace pg enum with zod schema

### DIFF
--- a/src/db/schema/enums/company.ts
+++ b/src/db/schema/enums/company.ts
@@ -1,14 +1,16 @@
-import { pgEnum } from "drizzle-orm/pg-core";
+import { z } from "zod";
 
-export const companyStatusEnum = pgEnum("company_status", [
+// Company status values
+export const COMPANY_STATUS = [
   "active", 
   "inactive", 
   "onboarding", 
   "suspended", 
   "lead"
-]);
+] as const;
 
-export const companyTypeEnum = pgEnum("company_type", [
+// Company type values
+export const COMPANY_TYPE = [
   "anonim_sirket", // A.Ş. - Anonim Şirket
   "limited_sirket", // Ltd. Şti. - Limited Şirket
   "kolektif_sirket", // Kolektif Şirket
@@ -19,4 +21,12 @@ export const companyTypeEnum = pgEnum("company_type", [
   "vakif", // Vakıf
   "sahis_isletmesi", // Şahıs İşletmesi
   "diger" // Diğer
-]);
+] as const;
+
+// Zod schemas
+export const companyStatusSchema = z.enum(COMPANY_STATUS);
+export const companyTypeSchema = z.enum(COMPANY_TYPE);
+
+// Type exports
+export type CompanyStatus = z.infer<typeof companyStatusSchema>;
+export type CompanyType = z.infer<typeof companyTypeSchema>;

--- a/src/db/schema/enums/customer.ts
+++ b/src/db/schema/enums/customer.ts
@@ -1,24 +1,37 @@
-import { pgEnum } from "drizzle-orm/pg-core";
+import { z } from "zod";
 
-export const customerStatusEnum = pgEnum("customer_status", [
+// Customer status values
+export const CUSTOMER_STATUS = [
   "active",
   "inactive",
   "prospect",
   "lead",
   "suspended",
   "closed"
-]);
+] as const;
 
-export const customerTypeEnum = pgEnum("customer_type", [
+// Customer type values
+export const CUSTOMER_TYPE = [
   "individual", // Bireysel müşteri
   "corporate" // Kurumsal müşteri
-]);
+] as const;
 
-export const customerCategoryEnum = pgEnum("customer_category", [
+// Customer category values
+export const CUSTOMER_CATEGORY = [
   "vip", // VIP müşteri
   "premium", // Premium müşteri
   "standard", // Standart müşteri
   "basic", // Temel müşteri
   "wholesale", // Toptan müşteri
   "retail" // Perakende müşteri
-]);
+] as const;
+
+// Zod schemas
+export const customerStatusSchema = z.enum(CUSTOMER_STATUS);
+export const customerTypeSchema = z.enum(CUSTOMER_TYPE);
+export const customerCategorySchema = z.enum(CUSTOMER_CATEGORY);
+
+// Type exports
+export type CustomerStatus = z.infer<typeof customerStatusSchema>;
+export type CustomerType = z.infer<typeof customerTypeSchema>;
+export type CustomerCategory = z.infer<typeof customerCategorySchema>;

--- a/src/db/schema/enums/product.ts
+++ b/src/db/schema/enums/product.ts
@@ -1,24 +1,27 @@
-import { pgEnum } from "drizzle-orm/pg-core";
+import { z } from "zod";
 
-export const productStatusEnum = pgEnum("product_status", [
+// Product status values
+export const PRODUCT_STATUS = [
   "active",
   "inactive",
   "draft",
   "discontinued",
   "out_of_stock",
   "coming_soon"
-]);
+] as const;
 
-export const productTypeEnum = pgEnum("product_type", [
+// Product type values
+export const PRODUCT_TYPE = [
   "physical", // Physical product
   "service", // Service
   "digital", // Digital product
   "bundle", // Product bundle
   "raw_material", // Raw material
   "consumable" // Consumable item
-]);
+] as const;
 
-export const productCategoryEnum = pgEnum("product_category", [
+// Product category values
+export const PRODUCT_CATEGORY = [
   "electronics",
   "clothing",
   "food_beverage",
@@ -33,9 +36,10 @@ export const productCategoryEnum = pgEnum("product_category", [
   "automotive",
   "construction",
   "other"
-]);
+] as const;
 
-export const productUnitEnum = pgEnum("product_unit", [
+// Product unit values
+export const PRODUCT_UNIT = [
   "piece", // Adet
   "kg", // Kilogram
   "g", // Gram
@@ -60,13 +64,28 @@ export const productUnitEnum = pgEnum("product_unit", [
   "sheet", // Tabaka
   "barrel", // Varil
   "other" // Diğer
-]);
+] as const;
 
-export const priceTypeEnum = pgEnum("price_type", [
+// Price type values
+export const PRICE_TYPE = [
   "purchase", // Purchase price
   "selling", // Selling price
   "list", // List price
   "special", // Special price
   "contract", // Contract price
   "promotional" // Promotional price
-]);
+] as const;
+
+// Zod schemas
+export const productStatusSchema = z.enum(PRODUCT_STATUS);
+export const productTypeSchema = z.enum(PRODUCT_TYPE);
+export const productCategorySchema = z.enum(PRODUCT_CATEGORY);
+export const productUnitSchema = z.enum(PRODUCT_UNIT);
+export const priceTypeSchema = z.enum(PRICE_TYPE);
+
+// Type exports
+export type ProductStatus = z.infer<typeof productStatusSchema>;
+export type ProductType = z.infer<typeof productTypeSchema>;
+export type ProductCategory = z.infer<typeof productCategorySchema>;
+export type ProductUnit = z.infer<typeof productUnitSchema>;
+export type PriceType = z.infer<typeof priceTypeSchema>;


### PR DESCRIPTION
Convert `pgEnum` definitions to Zod `z.enum` schemas for company, customer, and product entities.

---
<a href="https://cursor.com/background-agent?bcId=bc-731f0d83-96ac-4298-b115-9dcb60c55fba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-731f0d83-96ac-4298-b115-9dcb60c55fba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

